### PR TITLE
Patch: add early return to avoid checking fragments

### DIFF
--- a/dist/gqlRules/gqlVariableNameMatch/gqlVariableNameMatch.js
+++ b/dist/gqlRules/gqlVariableNameMatch/gqlVariableNameMatch.js
@@ -71,6 +71,8 @@ const create = (context)=>{
         const { init  } = node;
         const templateElementNode = init.quasi;
         const gqlOperationText = (0, _sanitizeGqlOperationText.sanitizeGqlOperationText)(templateElementNode, context);
+        // Return early to avoid checking fragments
+        if (!(0, _isGQLOperation.isQuery)(gqlOperationText) && !(0, _isGQLOperation.isMutation)(gqlOperationText)) return;
         isOperationNameAndVariableNameSame(gqlOperationText, node);
     };
     return {

--- a/src/gqlRules/gqlVariableNameMatch/gqlVariableNameMatch.js
+++ b/src/gqlRules/gqlVariableNameMatch/gqlVariableNameMatch.js
@@ -66,6 +66,8 @@ const create = context => {
     const { init } = node;
     const templateElementNode = init.quasi;
     const gqlOperationText = sanitizeGqlOperationText(templateElementNode, context);
+    // Return early to avoid checking fragments
+    if (!isQuery(gqlOperationText) && !isMutation(gqlOperationText)) return;
     isOperationNameAndVariableNameSame(gqlOperationText, node);
   };
 

--- a/src/gqlRules/gqlVariableNameMatch/gqlVariableNameMatch.js
+++ b/src/gqlRules/gqlVariableNameMatch/gqlVariableNameMatch.js
@@ -1,5 +1,5 @@
 import { isGqlFile } from "../utils";
-import { isQuery } from "../utils/isGQLOperation";
+import { isQuery, isMutation } from "../utils/isGQLOperation";
 import { relativePathToFile } from "../../utils";
 import { operationName } from "../utils/operationName";
 import { sanitizeGqlOperationText } from "../utils/sanitizeGqlOperationText";


### PR DESCRIPTION
This is to make sure we're checking only queries and mutations, and ignore fragments 