### PR TITLE
Update gqlOperationName to support mobile repo.

### DIFF
--- a/dist/gqlRules/gqlOperationName/gqlOperationName.js
+++ b/dist/gqlRules/gqlOperationName/gqlOperationName.js
@@ -37,10 +37,14 @@ const meta = {
                 },
                 namespaceOperationPrefix: {
                     type: "object"
+                },
+                sourcePath: {
+                    type: "string"
                 }
             },
             required: [
-                "namespaceOperationPrefix"
+                "namespaceOperationPrefix",
+                "sourcePath"
             ],
             additionalProperties: false
         }
@@ -48,13 +52,14 @@ const meta = {
 };
 const create = (context)=>{
     const isGqlObjectFile = (0, _utils.isGqlFile)(context);
-    const { namespaceOperationPrefix , namespaceIgnoreList  } = context.options[0];
+    const { namespaceOperationPrefix , namespaceIgnoreList: initialNamespaceIgnoreList , sourcePath  } = context.options[0];
+    const namespaceIgnoreList = initialNamespaceIgnoreList ?? [];
     const isGqlTemplateElement = (node)=>{
         return node.tag && node.tag.name === "gql";
     };
     const getNamespaceAndPrefix = ()=>{
         const pathToFile = (0, _utils1.relativePathToFile)(context);
-        const relativeJsPath = pathToFile.replace("app/javascript/", "");
+        const relativeJsPath = pathToFile.replace(sourcePath, "");
         const namespace = Object.keys(namespaceOperationPrefix).find((namespaceOperationKey)=>relativeJsPath.startsWith(namespaceOperationKey));
         return {
             namespace,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullscript/eslint-plugin",
-  "version": "1.6.1",
+  "version": "2.0.0",
   "description": "Fullscript custom eslint rules",
   "main": "dist/index.js",
   "contributors": [

--- a/src/gqlRules/gqlOperationName/gqlOperationName.js
+++ b/src/gqlRules/gqlOperationName/gqlOperationName.js
@@ -26,8 +26,11 @@ const meta = {
         namespaceOperationPrefix: {
           type: "object",
         },
+        sourcePath: {
+          type: "string",
+        },
       },
-      required: ["namespaceOperationPrefix"],
+      required: ["namespaceOperationPrefix", "sourcePath"],
       additionalProperties: false,
     },
   ],
@@ -35,7 +38,13 @@ const meta = {
 
 const create = context => {
   const isGqlObjectFile = isGqlFile(context);
-  const { namespaceOperationPrefix, namespaceIgnoreList } = context.options[0];
+  const {
+    namespaceOperationPrefix,
+    namespaceIgnoreList: initialNamespaceIgnoreList,
+    sourcePath,
+  } = context.options[0];
+
+  const namespaceIgnoreList = initialNamespaceIgnoreList ?? [];
 
   const isGqlTemplateElement = node => {
     return node.tag && node.tag.name === "gql";
@@ -43,7 +52,7 @@ const create = context => {
 
   const getNamespaceAndPrefix = () => {
     const pathToFile = relativePathToFile(context);
-    const relativeJsPath = pathToFile.replace("app/javascript/", "");
+    const relativeJsPath = pathToFile.replace(sourcePath, "");
 
     const namespace = Object.keys(namespaceOperationPrefix).find(namespaceOperationKey =>
       relativeJsPath.startsWith(namespaceOperationKey)


### PR DESCRIPTION
Added required `sourcePath` config property to gqlOperationName for the mobile repo. Added default value to `namespaceIgnoreList` to fix a bug that required `namespaceIgnoreList` to be configured as an empty array if not used.