### PR TITLE
Added noCreateMockInSetFunctions rule

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13,6 +13,7 @@ const _noRenamedTranslationImport = require("./noRenamedTranslationImport");
 const _noUnawaitedSkeletons = require("./noUnawaitedSkeletons");
 const _oneTranslationImport = require("./oneTranslationImport");
 const _noJestInProduction = require("./noJestInProduction");
+const _noCreateMockInSetFunctions = require("./noCreateMockInSetFunctions");
 const rules = {
     "one-translation-import-per-file": _oneTranslationImport.oneTranslationImport,
     "no-renamed-translation-import": _noRenamedTranslationImport.noRenamedTranslationImport,
@@ -22,5 +23,6 @@ const rules = {
     "cross-reference": _crossReference.crossReference,
     "circular-dependency": _circularDependency.circularDependency,
     "no-unawaited-skeletons": _noUnawaitedSkeletons.noUnawaitedSkeletons,
-    "no-jest-in-production": _noJestInProduction.noJestInProduction
+    "no-jest-in-production": _noJestInProduction.noJestInProduction,
+    "no-createMock-in-set-functions": _noCreateMockInSetFunctions.noCreateMockInSetFunctions
 };

--- a/dist/noCreateMockInSetFunctions/index.js
+++ b/dist/noCreateMockInSetFunctions/index.js
@@ -1,0 +1,48 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+Object.defineProperty(exports, "noCreateMockInSetFunctions", {
+    enumerable: true,
+    get: ()=>_noCreateMockInSetFunctions
+});
+const _noCreateMockInSetFunctions = /*#__PURE__*/ _interopRequireWildcard(require("./noCreateMockInSetFunctions"));
+function _getRequireWildcardCache(nodeInterop) {
+    if (typeof WeakMap !== "function") return null;
+    var cacheBabelInterop = new WeakMap();
+    var cacheNodeInterop = new WeakMap();
+    return (_getRequireWildcardCache = function(nodeInterop) {
+        return nodeInterop ? cacheNodeInterop : cacheBabelInterop;
+    })(nodeInterop);
+}
+function _interopRequireWildcard(obj, nodeInterop) {
+    if (!nodeInterop && obj && obj.__esModule) {
+        return obj;
+    }
+    if (obj === null || typeof obj !== "object" && typeof obj !== "function") {
+        return {
+            default: obj
+        };
+    }
+    var cache = _getRequireWildcardCache(nodeInterop);
+    if (cache && cache.has(obj)) {
+        return cache.get(obj);
+    }
+    var newObj = {};
+    var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor;
+    for(var key in obj){
+        if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) {
+            var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null;
+            if (desc && (desc.get || desc.set)) {
+                Object.defineProperty(newObj, key, desc);
+            } else {
+                newObj[key] = obj[key];
+            }
+        }
+    }
+    newObj.default = obj;
+    if (cache) {
+        cache.set(obj, newObj);
+    }
+    return newObj;
+}

--- a/dist/noCreateMockInSetFunctions/noCreateMockInSetFunctions.js
+++ b/dist/noCreateMockInSetFunctions/noCreateMockInSetFunctions.js
@@ -1,0 +1,133 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+function _export(target, all) {
+    for(var name in all)Object.defineProperty(target, name, {
+        enumerable: true,
+        get: all[name]
+    });
+}
+_export(exports, {
+    meta: ()=>meta,
+    create: ()=>create
+});
+const _utils = require("../utils");
+const meta = {
+    type: "problem",
+    docs: {
+        description: "Disallows nested createMock invokations in preference of maxDepth",
+        category: "createMock",
+        recommended: false
+    },
+    fixable: null,
+    schema: [
+        {
+            type: "object",
+            properties: {
+                setFunctions: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                }
+            },
+            required: [
+                "setFunctions"
+            ],
+            additionalProperties: false
+        }
+    ]
+};
+/**
+ * Determines if the passed expression is a spread of a ...createMock({}) call
+ * @param {import("@types/estree").Expression} expression
+ * @returns {boolean}
+ */ const isSpreadElementAndCreateMock = (node)=>{
+    return (0, _utils.isSpreadElement)(node) && (0, _utils.isCalleName)(node.argument, "createMock");
+};
+/**
+ * Determines if the passed expression is a call of createMock
+ * @param {import("@types/estree").Expression} expression
+ * @returns {boolean}
+ */ const isCallExpressionAndCreateMock = (node)=>{
+    return (0, _utils.isCallExpression)(node) && (0, _utils.isCalleName)(node, "createMock");
+};
+/**
+ * Determines if the passed expression is an object property and has a array or object value
+ * @param {import("@types/estree").Expression} expression
+ * @returns {boolean}
+ */ const isPropertyWithArrayOrObjectValue = (node)=>{
+    return (0, _utils.isProperty)(node) && ((0, _utils.isArrayExpression)(node.value) || (0, _utils.isObjectExpression)(node.value));
+};
+/**
+ * Determines if the specified Expression contains a call to createMock
+ * @param {import("@types/estree").Expression} expression
+ * @returns {boolean}
+ */ const hasNestedCreateMock = (expression)=>{
+    // Cases where you are passing a variable into setFunction
+    // setCurrentOffice(mockOffice);
+    // For now we will assume that mockOffice doesn't contain a call to createMock
+    if (!(0, _utils.isObjectExpression)(expression) && !(0, _utils.isArrayExpression)(expression)) return false;
+    // Objects contain properties, Arrays contain elements
+    return (expression.properties || expression.elements).some((node)=>{
+        if (isSpreadElementAndCreateMock(node)) {
+            // setCurrentOffice({ wholesaleCart: { ...createMock(...) } });
+            // OR
+            // setCurrentOffice({ ...createMock(...) });
+            return true;
+        } else if (isCallExpressionAndCreateMock(node)) {
+            // setViewer({ promotions: { nodes: [createMock(...)]}});
+            return true;
+        } else if ((0, _utils.isObjectExpression)(node)) {
+            //setCurrentStore({ promotions: { nodes: [ { foo: createMock(...) } ] }});
+            return hasNestedCreateMock(node);
+        } else if (isPropertyWithArrayOrObjectValue(node)) {
+            // setCurrentOffice({ cart: { billingAddress: createMock(...) } });
+            // OR
+            // setCurrentStore({ promotions: { nodes: [ { foo: createMock(...) }] } });
+            return hasNestedCreateMock(node.value);
+        } else if ((0, _utils.isProperty)(node) && isCallExpressionAndCreateMock(node.value)) {
+            // setCurrentOffice({ cart: createMock(...) });
+            return true;
+        }
+    });
+};
+/**
+ * Determines if the specified Identifier is a gql setFunction
+ * @param {import("@types/estree").Identifier} identifier
+ * @returns {boolean}
+ */ const isSetFunction = (identifier, setFunctions)=>{
+    return setFunctions.includes(identifier.name);
+};
+/**
+ * Detects usages of createMock within set*Functions such as setCurrentPatient, setCurrentPractitioner etc.
+ * The following example would violate this rule.
+ *
+ * ```ts
+ * setCurrentOffice({
+ *   wholesaleCart: {
+ *     id: "wholesale-1",
+ *     ...createMock({ typeName: "WholesaleOrder", overrides: { state: "New York"}}),
+ *   }
+ * })
+ * ```
+ * @param {import("@types/eslint").Rule.RuleContext} context
+ * @returns {import("@types/eslint").Rule.RuleListener}
+ */ const create = (context)=>{
+    const { setFunctions  } = context.options[0];
+    return {
+        CallExpression: (node)=>{
+            if (node.callee.type === "Identifier" && isSetFunction(node.callee, setFunctions)) {
+                const setFunctionName = node.callee.name;
+                const objectParam = node.arguments[0]; // setFunctions only ever have a single argument
+                if (hasNestedCreateMock(objectParam)) {
+                    context.report({
+                        node,
+                        message: `${setFunctionName} should not contain nested createMock call(s). You can specify overrides directly in ${setFunctionName}.`
+                    });
+                }
+            }
+        }
+    };
+};

--- a/dist/utils/ast/astUtils.js
+++ b/dist/utils/ast/astUtils.js
@@ -10,19 +10,27 @@ function _export(target, all) {
     });
 }
 _export(exports, {
-    isCallExpression: ()=>isCallExpression,
-    isLiteral: ()=>isLiteral,
+    findByPaths: ()=>findByPaths,
+    isArrayExpression: ()=>isArrayExpression,
     isAwaitExpression: ()=>isAwaitExpression,
     isCalleName: ()=>isCalleName,
+    isCallExpression: ()=>isCallExpression,
     isExpect: ()=>isExpect,
-    findByPaths: ()=>findByPaths
+    isLiteral: ()=>isLiteral,
+    isObjectExpression: ()=>isObjectExpression,
+    isProperty: ()=>isProperty,
+    isSpreadElement: ()=>isSpreadElement
 });
 const isType = (node, type)=>{
     return (node === null || node === void 0 ? void 0 : node.type) === type;
 };
 const isCallExpression = (node)=>isType(node, "CallExpression");
+const isObjectExpression = (node)=>isType(node, "ObjectExpression");
+const isArrayExpression = (node)=>isType(node, "ArrayExpression");
+const isSpreadElement = (node)=>isType(node, "SpreadElement");
 const isLiteral = (node)=>isType(node, "Literal");
 const isAwaitExpression = (node)=>isType(node, "AwaitExpression");
+const isProperty = (node)=>isType(node, "Property");
 // calee
 const isCalleName = (node, name)=>{
     var _node_callee;

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { noRenamedTranslationImport } from "./noRenamedTranslationImport";
 import { noUnawaitedSkeletons } from "./noUnawaitedSkeletons";
 import { oneTranslationImport } from "./oneTranslationImport";
 import { noJestInProduction } from "./noJestInProduction";
+import { noCreateMockInSetFunctions } from "./noCreateMockInSetFunctions";
 
 const rules = {
   "one-translation-import-per-file": oneTranslationImport,
@@ -16,6 +17,7 @@ const rules = {
   "circular-dependency": circularDependency,
   "no-unawaited-skeletons": noUnawaitedSkeletons,
   "no-jest-in-production": noJestInProduction,
+  "no-createMock-in-set-functions": noCreateMockInSetFunctions,
 };
 
 export { rules };

--- a/src/noCreateMockInSetFunctions/index.js
+++ b/src/noCreateMockInSetFunctions/index.js
@@ -1,0 +1,1 @@
+export * as noCreateMockInSetFunctions from "./noCreateMockInSetFunctions";

--- a/src/noCreateMockInSetFunctions/noCreateMockInSetFunctions.js
+++ b/src/noCreateMockInSetFunctions/noCreateMockInSetFunctions.js
@@ -1,0 +1,142 @@
+import {
+  isObjectExpression,
+  isArrayExpression,
+  isSpreadElement,
+  isCallExpression,
+  isProperty,
+  isCalleName,
+} from "../utils";
+
+const meta = {
+  type: "problem",
+  docs: {
+    description: "Disallows nested createMock invokations in preference of maxDepth",
+    category: "createMock",
+    recommended: false,
+  },
+  fixable: null,
+  schema: [
+    {
+      type: "object",
+      properties: {
+        setFunctions: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["setFunctions"],
+      additionalProperties: false,
+    },
+  ],
+};
+
+/**
+ * Determines if the passed expression is a spread of a ...createMock({}) call
+ * @param {import("@types/estree").Expression} expression
+ * @returns {boolean}
+ */
+const isSpreadElementAndCreateMock = node => {
+  return isSpreadElement(node) && isCalleName(node.argument, "createMock");
+};
+
+/**
+ * Determines if the passed expression is a call of createMock
+ * @param {import("@types/estree").Expression} expression
+ * @returns {boolean}
+ */
+const isCallExpressionAndCreateMock = node => {
+  return isCallExpression(node) && isCalleName(node, "createMock");
+};
+
+/**
+ * Determines if the passed expression is an object property and has a array or object value
+ * @param {import("@types/estree").Expression} expression
+ * @returns {boolean}
+ */
+const isPropertyWithArrayOrObjectValue = node => {
+  return isProperty(node) && (isArrayExpression(node.value) || isObjectExpression(node.value));
+};
+
+/**
+ * Determines if the specified Expression contains a call to createMock
+ * @param {import("@types/estree").Expression} expression
+ * @returns {boolean}
+ */
+const hasNestedCreateMock = expression => {
+  // Cases where you are passing a variable into setFunction
+  // setCurrentOffice(mockOffice);
+  // For now we will assume that mockOffice doesn't contain a call to createMock
+  if (!isObjectExpression(expression) && !isArrayExpression(expression)) return false;
+
+  // Objects contain properties, Arrays contain elements
+  return (expression.properties || expression.elements).some(node => {
+    if (isSpreadElementAndCreateMock(node)) {
+      // setCurrentOffice({ wholesaleCart: { ...createMock(...) } });
+      // OR
+      // setCurrentOffice({ ...createMock(...) });
+      return true;
+    } else if (isCallExpressionAndCreateMock(node)) {
+      // setViewer({ promotions: { nodes: [createMock(...)]}});
+      return true;
+    } else if (isObjectExpression(node)) {
+      //setCurrentStore({ promotions: { nodes: [ { foo: createMock(...) } ] }});
+      return hasNestedCreateMock(node);
+    } else if (isPropertyWithArrayOrObjectValue(node)) {
+      // setCurrentOffice({ cart: { billingAddress: createMock(...) } });
+      // OR
+      // setCurrentStore({ promotions: { nodes: [ { foo: createMock(...) }] } });
+      return hasNestedCreateMock(node.value);
+    } else if (isProperty(node) && isCallExpressionAndCreateMock(node.value)) {
+      // setCurrentOffice({ cart: createMock(...) });
+      return true;
+    }
+  });
+};
+
+/**
+ * Determines if the specified Identifier is a gql setFunction
+ * @param {import("@types/estree").Identifier} identifier
+ * @returns {boolean}
+ */
+const isSetFunction = (identifier, setFunctions) => {
+  return setFunctions.includes(identifier.name);
+};
+
+/**
+ * Detects usages of createMock within set*Functions such as setCurrentPatient, setCurrentPractitioner etc.
+ * The following example would violate this rule.
+ *
+ * ```ts
+ * setCurrentOffice({
+ *   wholesaleCart: {
+ *     id: "wholesale-1",
+ *     ...createMock({ typeName: "WholesaleOrder", overrides: { state: "New York"}}),
+ *   }
+ * })
+ * ```
+ * @param {import("@types/eslint").Rule.RuleContext} context
+ * @returns {import("@types/eslint").Rule.RuleListener}
+ */
+const create = context => {
+  const { setFunctions } = context.options[0];
+
+  return {
+    CallExpression: node => {
+      if (node.callee.type === "Identifier" && isSetFunction(node.callee, setFunctions)) {
+        const setFunctionName = node.callee.name;
+        const objectParam = node.arguments[0]; // setFunctions only ever have a single argument
+
+        if (hasNestedCreateMock(objectParam)) {
+          context.report({
+            node,
+            message: `${setFunctionName} should not contain nested createMock call(s). You can specify overrides directly in ${setFunctionName}.`,
+          });
+        }
+      }
+    },
+  };
+};
+
+export { meta, create };

--- a/src/utils/ast/astUtils.js
+++ b/src/utils/ast/astUtils.js
@@ -1,8 +1,12 @@
 // types
 const isType = (node, type) => node?.type === type;
 const isCallExpression = node => isType(node, "CallExpression");
+const isObjectExpression = node => isType(node, "ObjectExpression");
+const isArrayExpression = node => isType(node, "ArrayExpression");
+const isSpreadElement = node => isType(node, "SpreadElement");
 const isLiteral = node => isType(node, "Literal");
 const isAwaitExpression = node => isType(node, "AwaitExpression");
+const isProperty = node => isType(node, "Property");
 
 // calee
 const isCalleName = (node, name) => node?.callee?.name === name;
@@ -25,4 +29,15 @@ const findByPaths = (paths, tree) => {
   return null;
 };
 
-export { isCallExpression, isLiteral, isAwaitExpression, isCalleName, isExpect, findByPaths };
+export {
+  findByPaths,
+  isArrayExpression,
+  isAwaitExpression,
+  isCalleName,
+  isCallExpression,
+  isExpect,
+  isLiteral,
+  isObjectExpression,
+  isProperty,
+  isSpreadElement,
+};


### PR DESCRIPTION
For example, this below screenshot is a demonstration where `createMock` isn't required as we're not specifying any overrides.
GraphQL auto-mocking will generate the same fake data as `createMock` so it's not required. We need only specify anything that we want to have an explicit value.

![image](https://github.com/Fullscript/eslint-plugin/assets/5891054/c1845bd1-b6ec-4bd0-9140-3e08106a9f66)


can be re-written to:

![image](https://github.com/Fullscript/eslint-plugin/assets/5891054/402aee25-c72a-41fe-923f-9248f659537c)
