### PR TITLE
No gql manual hook declaration

### DIFF
--- a/dist/gqlRules/gqlNoManualHookDeclaration/gqlNoManualHookDeclaration.js
+++ b/dist/gqlRules/gqlNoManualHookDeclaration/gqlNoManualHookDeclaration.js
@@ -1,0 +1,77 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+function _export(target, all) {
+    for(var name in all)Object.defineProperty(target, name, {
+        enumerable: true,
+        get: all[name]
+    });
+}
+_export(exports, {
+    meta: ()=>meta,
+    create: ()=>create
+});
+const _utils = require("../utils");
+const _utils1 = require("../../utils");
+const meta = {
+    type: "problem",
+    docs: {
+        description: "Disallows hooks to be exported in the GQL source file. Encourages to use the generated hooks in query|mutation.generated.tsx",
+        category: "gql-no-manual-hook-declaration",
+        recommended: false
+    },
+    fixable: null,
+    schema: [
+        {
+            type: "object",
+            properties: {
+                namespaceIgnoreList: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                }
+            },
+            additionalProperties: false
+        }
+    ]
+};
+const reactHookPrefix = new RegExp("use\\w+");
+const create = (context)=>{
+    var _context_options, _context_options_;
+    const isGqlObjectFile = (0, _utils.isGqlFile)(context);
+    const ignoreList = (context === null || context === void 0 ? void 0 : (_context_options = context.options) === null || _context_options === void 0 ? void 0 : (_context_options_ = _context_options[0]) === null || _context_options_ === void 0 ? void 0 : _context_options_.namespaceIgnoreList) ?? [];
+    const isInIgnoreList = ()=>{
+        if (!(ignoreList === null || ignoreList === void 0 ? void 0 : ignoreList.length)) return false;
+        const pathToFile = (0, _utils1.relativePathToFile)(context);
+        return ignoreList.some((ignoredNamespace)=>pathToFile.startsWith(ignoredNamespace));
+    };
+    if (isInIgnoreList() || !isGqlObjectFile) return {}; // return early before going through nodes
+    const isHookDeclaredManually = (node, name)=>{
+        if (reactHookPrefix.test(name)) {
+            context.report({
+                node: node,
+                message: `The hook "${name}" is manually exported from this file. Please use the hook from the corresponding query or mutation generated file located next to this file instead"`
+            });
+        }
+    };
+    const ExportNamedDeclaration = (node)=>{
+        // no values in export statement
+        if (node.exportKind !== "value") return;
+        // When the variable is directly exported like so export const usePatientQuery =...
+        if (node.declaration && node.declaration.declarations) {
+            node.declaration.declarations.forEach((declaration)=>{
+                isHookDeclaredManually(node, declaration.id.name);
+            });
+        } else {
+            // When the variable is in the export statement like so export { usePatientQuery }
+            node.specifiers.forEach(({ local  })=>{
+                isHookDeclaredManually(node, local.name);
+            });
+        }
+    };
+    return {
+        ExportNamedDeclaration
+    };
+};

--- a/dist/gqlRules/gqlNoManualHookDeclaration/index.js
+++ b/dist/gqlRules/gqlNoManualHookDeclaration/index.js
@@ -1,0 +1,48 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+Object.defineProperty(exports, "gqlNoManualHookDeclaration", {
+    enumerable: true,
+    get: ()=>_gqlNoManualHookDeclaration
+});
+const _gqlNoManualHookDeclaration = /*#__PURE__*/ _interopRequireWildcard(require("./gqlNoManualHookDeclaration"));
+function _getRequireWildcardCache(nodeInterop) {
+    if (typeof WeakMap !== "function") return null;
+    var cacheBabelInterop = new WeakMap();
+    var cacheNodeInterop = new WeakMap();
+    return (_getRequireWildcardCache = function(nodeInterop) {
+        return nodeInterop ? cacheNodeInterop : cacheBabelInterop;
+    })(nodeInterop);
+}
+function _interopRequireWildcard(obj, nodeInterop) {
+    if (!nodeInterop && obj && obj.__esModule) {
+        return obj;
+    }
+    if (obj === null || typeof obj !== "object" && typeof obj !== "function") {
+        return {
+            default: obj
+        };
+    }
+    var cache = _getRequireWildcardCache(nodeInterop);
+    if (cache && cache.has(obj)) {
+        return cache.get(obj);
+    }
+    var newObj = {};
+    var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor;
+    for(var key in obj){
+        if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) {
+            var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null;
+            if (desc && (desc.get || desc.set)) {
+                Object.defineProperty(newObj, key, desc);
+            } else {
+                newObj[key] = obj[key];
+            }
+        }
+    }
+    newObj.default = obj;
+    if (cache) {
+        cache.set(obj, newObj);
+    }
+    return newObj;
+}

--- a/dist/gqlRules/index.js
+++ b/dist/gqlRules/index.js
@@ -5,6 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 _exportStar(require("./gqlObjects"), exports);
 _exportStar(require("./gqlOperationName"), exports);
 _exportStar(require("./gqlVariableNameMatch"), exports);
+_exportStar(require("./gqlNoManualHookDeclaration"), exports);
 function _exportStar(from, to) {
     Object.keys(from).forEach(function(k) {
         if (k !== "default" && !Object.prototype.hasOwnProperty.call(to, k)) Object.defineProperty(to, k, {

--- a/dist/index.js
+++ b/dist/index.js
@@ -26,5 +26,6 @@ const rules = {
     "no-unawaited-skeletons": _noUnawaitedSkeletons.noUnawaitedSkeletons,
     "no-jest-in-production": _noJestInProduction.noJestInProduction,
     "no-createMock-in-set-functions": _noCreateMockInSetFunctions.noCreateMockInSetFunctions,
-    "no-invalid-feature": _noInvalidFeature.noInvalidFeature
+    "no-invalid-feature": _noInvalidFeature.noInvalidFeature,
+    "gql-no-manual-hook-declaration": _gqlRules.gqlNoManualHookDeclaration
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullscript/eslint-plugin",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Fullscript custom eslint rules",
   "main": "dist/index.js",
   "contributors": [

--- a/src/gqlRules/gqlNoManualHookDeclaration/gqlNoManualHookDeclaration.js
+++ b/src/gqlRules/gqlNoManualHookDeclaration/gqlNoManualHookDeclaration.js
@@ -37,8 +37,6 @@ const create = context => {
     return namespaceIgnoreList.some(ignoredNamespace => pathToFile.startsWith(ignoredNamespace));
   };
 
-  if (isInIgnoreList()) return;
-
   const isHookDeclaredManually = (node, name) => {
     if (reactHookPrefix.test(name)) {
       context.report({
@@ -50,7 +48,7 @@ const create = context => {
 
   const ExportNamedDeclaration = node => {
     // not a gql file or no value exported
-    if (!isGqlObjectFile || node.exportKind !== "value") return;
+    if (isInIgnoreList() || !isGqlObjectFile || node.exportKind !== "value") return;
 
     // When the variable is directly exported like so export const usePatientQuery =...
     if (node.declaration && node.declaration.declarations) {

--- a/src/gqlRules/gqlNoManualHookDeclaration/gqlNoManualHookDeclaration.js
+++ b/src/gqlRules/gqlNoManualHookDeclaration/gqlNoManualHookDeclaration.js
@@ -30,12 +30,15 @@ const reactHookPrefix = new RegExp("use\\w+");
 
 const create = context => {
   const isGqlObjectFile = isGqlFile(context);
-  const { namespaceIgnoreList } = context.options[0];
+  const ignoreList = context?.options?.[0]?.namespaceIgnoreList ?? [];
 
   const isInIgnoreList = () => {
+    if (!ignoreList?.length) return false;
     const pathToFile = relativePathToFile(context);
-    return namespaceIgnoreList.some(ignoredNamespace => pathToFile.startsWith(ignoredNamespace));
+    return ignoreList.some(ignoredNamespace => pathToFile.startsWith(ignoredNamespace));
   };
+
+  if (isInIgnoreList() || !isGqlObjectFile) return {}; // return early before going through nodes
 
   const isHookDeclaredManually = (node, name) => {
     if (reactHookPrefix.test(name)) {
@@ -47,8 +50,8 @@ const create = context => {
   };
 
   const ExportNamedDeclaration = node => {
-    // not a gql file or no value exported
-    if (isInIgnoreList() || !isGqlObjectFile || node.exportKind !== "value") return;
+    // no values in export statement
+    if (node.exportKind !== "value") return;
 
     // When the variable is directly exported like so export const usePatientQuery =...
     if (node.declaration && node.declaration.declarations) {

--- a/src/gqlRules/gqlNoManualHookDeclaration/gqlNoManualHookDeclaration.js
+++ b/src/gqlRules/gqlNoManualHookDeclaration/gqlNoManualHookDeclaration.js
@@ -1,0 +1,71 @@
+import { isGqlFile } from "../utils";
+import { relativePathToFile } from "../../utils";
+
+const meta = {
+  type: "problem",
+  docs: {
+    description:
+      "Disallows hooks to be exported in the GQL source file. Encourages to use the generated hooks in query|mutation.generated.tsx",
+    category: "gql-no-manual-hook-declaration",
+    recommended: false,
+  },
+  fixable: null,
+  schema: [
+    {
+      type: "object",
+      properties: {
+        namespaceIgnoreList: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      additionalProperties: false,
+    },
+  ],
+};
+
+const reactHookPrefix = new RegExp("use\\w+");
+
+const create = context => {
+  const isGqlObjectFile = isGqlFile(context);
+  const { namespaceIgnoreList } = context.options[0];
+
+  const isInIgnoreList = () => {
+    const pathToFile = relativePathToFile(context);
+    return namespaceIgnoreList.some(ignoredNamespace => pathToFile.startsWith(ignoredNamespace));
+  };
+
+  if (isInIgnoreList()) return;
+
+  const isHookDeclaredManually = (node, name) => {
+    if (reactHookPrefix.test(name)) {
+      context.report({
+        node: node,
+        message: `The hook "${name}" is manually exported from this file. Please use the hook from the corresponding query or mutation generated file located next to this file instead"`,
+      });
+    }
+  };
+
+  const ExportNamedDeclaration = node => {
+    // not a gql file or no value exported
+    if (!isGqlObjectFile || node.exportKind !== "value") return;
+
+    // When the variable is directly exported like so export const usePatientQuery =...
+    if (node.declaration && node.declaration.declarations) {
+      node.declaration.declarations.forEach(declaration => {
+        isHookDeclaredManually(node, declaration.id.name);
+      });
+    } else {
+      // When the variable is in the export statement like so export { usePatientQuery }
+      node.specifiers.forEach(({ local }) => {
+        isHookDeclaredManually(node, local.name);
+      });
+    }
+  };
+
+  return { ExportNamedDeclaration };
+};
+
+export { meta, create };

--- a/src/gqlRules/gqlNoManualHookDeclaration/index.js
+++ b/src/gqlRules/gqlNoManualHookDeclaration/index.js
@@ -1,0 +1,1 @@
+export * as gqlNoManualHookDeclaration from "./gqlNoManualHookDeclaration";

--- a/src/gqlRules/index.js
+++ b/src/gqlRules/index.js
@@ -1,3 +1,4 @@
 export * from "./gqlObjects";
 export * from "./gqlOperationName";
 export * from "./gqlVariableNameMatch";
+export * from "./gqlNoManualHookDeclaration";

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,11 @@
 import { circularDependency } from "./circularDependency";
 import { crossReference } from "./crossReference";
-import { gqlObjects, gqlOperationName, gqlVariableNameMatch } from "./gqlRules";
+import {
+  gqlObjects,
+  gqlOperationName,
+  gqlVariableNameMatch,
+  gqlNoManualHookDeclaration,
+} from "./gqlRules";
 import { noRenamedTranslationImport } from "./noRenamedTranslationImport";
 import { noUnawaitedSkeletons } from "./noUnawaitedSkeletons";
 import { oneTranslationImport } from "./oneTranslationImport";
@@ -18,6 +23,7 @@ const rules = {
   "no-unawaited-skeletons": noUnawaitedSkeletons,
   "no-jest-in-production": noJestInProduction,
   "no-createMock-in-set-functions": noCreateMockInSetFunctions,
+  "gql-no-manual-hook-declaration": gqlNoManualHookDeclaration,
 };
 
 export { rules };


### PR DESCRIPTION
When a gql quries/mutations are converted, we don't want people who are creating a new queries to manually declare a hook and export them. 

This rule prevents the users from exporting the hook so people will be aware that they have to use the generated queries instead.

I will add the dist folder once it's approved