### PR TITLE
Add eslint rule for aviary box isColor and accentColor usage

### DIFF
--- a/dist/aviaryRules/aviaryNoClashingBoxColorProps/aviaryNoClashingBoxColorProps.js
+++ b/dist/aviaryRules/aviaryNoClashingBoxColorProps/aviaryNoClashingBoxColorProps.js
@@ -1,0 +1,40 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+function _export(target, all) {
+    for(var name in all)Object.defineProperty(target, name, {
+        enumerable: true,
+        get: all[name]
+    });
+}
+_export(exports, {
+    meta: ()=>meta,
+    create: ()=>create
+});
+const meta = {
+    type: "problem",
+    docs: {
+        description: "Prevents isColor and accentColor from being passed to the same Box component",
+        category: "no-clashing-box-color-props",
+        recommended: false
+    },
+    fixable: null,
+    schema: []
+};
+const create = (context)=>{
+    return {
+        JSXOpeningElement: (node)=>{
+            if (node.name.name !== "Box") return;
+            const attributes = node.attributes;
+            const isColor = attributes.find((attr)=>attr.name.name === "isColor");
+            const accentColor = attributes.find((attr)=>attr.name.name === "accentColor");
+            if (isColor && accentColor) {
+                context.report({
+                    node,
+                    message: "Do not use both isColor and accentColor in the same Box component. They are clashing props."
+                });
+            }
+        }
+    };
+};

--- a/dist/aviaryRules/aviaryNoClashingBoxColorProps/aviaryNoClashingBoxColorProps.js
+++ b/dist/aviaryRules/aviaryNoClashingBoxColorProps/aviaryNoClashingBoxColorProps.js
@@ -27,8 +27,8 @@ const create = (context)=>{
         JSXOpeningElement: (node)=>{
             if (node.name.name !== "Box") return;
             const attributes = node.attributes;
-            const isColor = attributes.find((attr)=>attr.name.name === "isColor");
-            const accentColor = attributes.find((attr)=>attr.name.name === "accentColor");
+            const isColor = attributes.find((attr)=>attr.type === "JSXAttribute" && attr.name.name === "isColor");
+            const accentColor = attributes.find((attr)=>attr.type === "JSXAttribute" && attr.name.name === "accentColor");
             if (isColor && accentColor) {
                 context.report({
                     node,

--- a/dist/aviaryRules/aviaryNoClashingBoxColorProps/index.js
+++ b/dist/aviaryRules/aviaryNoClashingBoxColorProps/index.js
@@ -1,0 +1,48 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+Object.defineProperty(exports, "aviaryNoClashingBoxColorProps", {
+    enumerable: true,
+    get: ()=>_aviaryNoClashingBoxColorProps
+});
+const _aviaryNoClashingBoxColorProps = /*#__PURE__*/ _interopRequireWildcard(require("./aviaryNoClashingBoxColorProps"));
+function _getRequireWildcardCache(nodeInterop) {
+    if (typeof WeakMap !== "function") return null;
+    var cacheBabelInterop = new WeakMap();
+    var cacheNodeInterop = new WeakMap();
+    return (_getRequireWildcardCache = function(nodeInterop) {
+        return nodeInterop ? cacheNodeInterop : cacheBabelInterop;
+    })(nodeInterop);
+}
+function _interopRequireWildcard(obj, nodeInterop) {
+    if (!nodeInterop && obj && obj.__esModule) {
+        return obj;
+    }
+    if (obj === null || typeof obj !== "object" && typeof obj !== "function") {
+        return {
+            default: obj
+        };
+    }
+    var cache = _getRequireWildcardCache(nodeInterop);
+    if (cache && cache.has(obj)) {
+        return cache.get(obj);
+    }
+    var newObj = {};
+    var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor;
+    for(var key in obj){
+        if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) {
+            var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null;
+            if (desc && (desc.get || desc.set)) {
+                Object.defineProperty(newObj, key, desc);
+            } else {
+                newObj[key] = obj[key];
+            }
+        }
+    }
+    newObj.default = obj;
+    if (cache) {
+        cache.set(obj, newObj);
+    }
+    return newObj;
+}

--- a/dist/aviaryRules/index.js
+++ b/dist/aviaryRules/index.js
@@ -1,0 +1,16 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+_exportStar(require("./aviaryNoClashingBoxColorProps"), exports);
+function _exportStar(from, to) {
+    Object.keys(from).forEach(function(k) {
+        if (k !== "default" && !Object.prototype.hasOwnProperty.call(to, k)) Object.defineProperty(to, k, {
+            enumerable: true,
+            get: function() {
+                return from[k];
+            }
+        });
+    });
+    return from;
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -15,6 +15,7 @@ const _oneTranslationImport = require("./oneTranslationImport");
 const _noJestInProduction = require("./noJestInProduction");
 const _noCreateMockInSetFunctions = require("./noCreateMockInSetFunctions");
 const _noInvalidFeature = require("./noInvalidFeature");
+const _aviaryRules = require("./aviaryRules");
 const rules = {
     "one-translation-import-per-file": _oneTranslationImport.oneTranslationImport,
     "no-renamed-translation-import": _noRenamedTranslationImport.noRenamedTranslationImport,
@@ -27,5 +28,6 @@ const rules = {
     "no-jest-in-production": _noJestInProduction.noJestInProduction,
     "no-createMock-in-set-functions": _noCreateMockInSetFunctions.noCreateMockInSetFunctions,
     "no-invalid-feature": _noInvalidFeature.noInvalidFeature,
-    "gql-no-manual-hook-declaration": _gqlRules.gqlNoManualHookDeclaration
+    "gql-no-manual-hook-declaration": _gqlRules.gqlNoManualHookDeclaration,
+    "aviary-no-clashing-box-color-props": _aviaryRules.aviaryNoClashingBoxColorProps
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullscript/eslint-plugin",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Fullscript custom eslint rules",
   "main": "dist/index.js",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullscript/eslint-plugin",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Fullscript custom eslint rules",
   "main": "dist/index.js",
   "contributors": [
@@ -9,7 +9,8 @@
     "Aidan Feuerherm <aidan.feuerherm@fullscript.com>",
     "Valentyn Patsera <valentyn.patsera@fullscript.com>",
     "Omar Nasr <omar.nasr@fullscript.com>",
-    "Asuka Kuwahara <asuka.kuwahara@fullscript.com>"
+    "Asuka Kuwahara <asuka.kuwahara@fullscript.com>",
+    "Benaiah Barango <benaiah.barango@fullscript.com>"
   ],
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullscript/eslint-plugin",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Fullscript custom eslint rules",
   "main": "dist/index.js",
   "contributors": [

--- a/src/aviaryRules/aviaryNoClashingBoxColorProps/aviaryNoClashingBoxColorProps.js
+++ b/src/aviaryRules/aviaryNoClashingBoxColorProps/aviaryNoClashingBoxColorProps.js
@@ -16,8 +16,12 @@ const create = context => {
 
       const attributes = node.attributes;
 
-      const isColor = attributes.find(attr => attr.name.name === "isColor");
-      const accentColor = attributes.find(attr => attr.name.name === "accentColor");
+      const isColor = attributes.find(
+        attr => attr.type === "JSXAttribute" && attr.name.name === "isColor"
+      );
+      const accentColor = attributes.find(
+        attr => attr.type === "JSXAttribute" && attr.name.name === "accentColor"
+      );
 
       if (isColor && accentColor) {
         context.report({

--- a/src/aviaryRules/aviaryNoClashingBoxColorProps/aviaryNoClashingBoxColorProps.js
+++ b/src/aviaryRules/aviaryNoClashingBoxColorProps/aviaryNoClashingBoxColorProps.js
@@ -1,0 +1,33 @@
+const meta = {
+  type: "problem",
+  docs: {
+    description: "Prevents isColor and accentColor from being passed to the same Box component",
+    category: "no-clashing-box-color-props",
+    recommended: false,
+  },
+  fixable: null,
+  schema: [],
+};
+
+const create = context => {
+  return {
+    JSXOpeningElement: node => {
+      if (node.name.name !== "Box") return;
+
+      const attributes = node.attributes;
+
+      const isColor = attributes.find(attr => attr.name.name === "isColor");
+      const accentColor = attributes.find(attr => attr.name.name === "accentColor");
+
+      if (isColor && accentColor) {
+        context.report({
+          node,
+          message:
+            "Do not use both isColor and accentColor in the same Box component. They are clashing props.",
+        });
+      }
+    },
+  };
+};
+
+export { meta, create };

--- a/src/aviaryRules/aviaryNoClashingBoxColorProps/index.js
+++ b/src/aviaryRules/aviaryNoClashingBoxColorProps/index.js
@@ -1,0 +1,1 @@
+export * as aviaryNoClashingBoxColorProps from "./aviaryNoClashingBoxColorProps";

--- a/src/aviaryRules/index.js
+++ b/src/aviaryRules/index.js
@@ -1,0 +1,1 @@
+export * from "./aviaryNoClashingBoxColorProps";

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import { oneTranslationImport } from "./oneTranslationImport";
 import { noJestInProduction } from "./noJestInProduction";
 import { noCreateMockInSetFunctions } from "./noCreateMockInSetFunctions";
 import { noInvalidFeature } from "./noInvalidFeature";
+import { aviaryNoClashingBoxColorProps } from "./aviaryRules";
 
 const rules = {
   "one-translation-import-per-file": oneTranslationImport,
@@ -26,6 +27,7 @@ const rules = {
   "no-createMock-in-set-functions": noCreateMockInSetFunctions,
   "no-invalid-feature": noInvalidFeature,
   "gql-no-manual-hook-declaration": gqlNoManualHookDeclaration,
+  "aviary-no-clashing-box-color-props": aviaryNoClashingBoxColorProps,
 };
 
 export { rules };


### PR DESCRIPTION
First eslint rule, yay!

Example implementation:

![image](https://github.com/Fullscript/eslint-plugin/assets/22198877/a891bf43-693a-4857-8c85-05f73e6cc520)


## Testing

1. Pull down this branch locally and test against hw-admin using `yarn eslint-diff`
2. Make sure there are no errors
