### PR TITLE
Fix regex for gql manual hook

### DIFF
--- a/dist/gqlRules/gqlNoManualHookDeclaration/gqlNoManualHookDeclaration.js
+++ b/dist/gqlRules/gqlNoManualHookDeclaration/gqlNoManualHookDeclaration.js
@@ -37,7 +37,7 @@ const meta = {
         }
     ]
 };
-const reactHookPrefix = new RegExp("use\\w+");
+const reactHookPrefix = new RegExp("^use\\w+");
 const create = (context)=>{
     var _context_options, _context_options_;
     const isGqlObjectFile = (0, _utils.isGqlFile)(context);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullscript/eslint-plugin",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Fullscript custom eslint rules",
   "main": "dist/index.js",
   "contributors": [

--- a/src/gqlRules/gqlNoManualHookDeclaration/gqlNoManualHookDeclaration.js
+++ b/src/gqlRules/gqlNoManualHookDeclaration/gqlNoManualHookDeclaration.js
@@ -26,7 +26,7 @@ const meta = {
   ],
 };
 
-const reactHookPrefix = new RegExp("use\\w+");
+const reactHookPrefix = new RegExp("^use\\w+");
 
 const create = context => {
   const isGqlObjectFile = isGqlFile(context);


### PR DESCRIPTION
This existing regex will check all the instances of `use`, not only when it's in the prefix so it'll be problematic when types or other types of export declaration includes `use` inside their variable.