### PR TITLE
Updated cross-reference eslint rule to fix falsly reporting @remix-run as a violation

### DIFF
--- a/dist/crossReference/crossReference.js
+++ b/dist/crossReference/crossReference.js
@@ -12,7 +12,7 @@ _export(exports, {
     meta: ()=>meta,
     create: ()=>create
 });
-const _path = /*#__PURE__*/ _interopRequireDefault(require("path"));
+const _nodePath = /*#__PURE__*/ _interopRequireDefault(require("node:path"));
 const _getModules = require("./getModules");
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : {
@@ -82,22 +82,25 @@ const create = (context)=>{
         return configEntry;
     });
     const getModule = (filePath, { directory  })=>{
-        const basePath = _path.default.join(relativeAppPath, directory);
+        const basePath = _nodePath.default.join(relativeAppPath, directory);
         const jsIndex = filePath.indexOf(basePath);
         if (jsIndex === -1) {
             return null;
         }
         const name = filePath.substring(jsIndex).replace(relativeAppPath, "").replace(directory, "").split("/").filter((val)=>val)[0];
-        return _path.default.join(directory, name);
+        return _nodePath.default.join(directory, name);
     };
     const getImportModule = (importPath, config)=>{
         const jsModule = getModule(importPath, config);
         if (jsModule) {
             return jsModule;
         }
-        return config.modules.find((moduleName)=>importPath.startsWith(`${moduleName}/`)) || config.modules.find((moduleName)=>importPath.startsWith(moduleName));
+        // Checks to see if the import path is a namespace within the application or an external node module
+        const isImportPathAnAppNamespace = config.modules.find((moduleName)=>moduleName.startsWith(importPath.split("/")[0]));
+        return isImportPathAnAppNamespace && (config.modules.find((moduleName)=>importPath.startsWith(`${moduleName}/`)) || config.modules.find((moduleName)=>importPath.startsWith(moduleName)));
     };
     const isValidConfig = (node, config)=>{
+        debugger;
         const fileModule = getModule(context.getFilename(), config);
         if (!fileModule) return true;
         const whitelisted = config.allowlistDirectories.includes(fileModule);

--- a/dist/crossReference/getModules.js
+++ b/dist/crossReference/getModules.js
@@ -6,13 +6,13 @@ Object.defineProperty(exports, "getModules", {
     enumerable: true,
     get: ()=>getModules
 });
-const _fs = /*#__PURE__*/ _interopRequireDefault(require("fs"));
-const _path = /*#__PURE__*/ _interopRequireDefault(require("path"));
+const _nodeFs = /*#__PURE__*/ _interopRequireDefault(require("node:fs"));
+const _nodePath = /*#__PURE__*/ _interopRequireDefault(require("node:path"));
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : {
         default: obj
     };
 }
 const getModules = (absoluteAppPath, dir)=>{
-    return _fs.default.readdirSync(_path.default.resolve(absoluteAppPath, dir)).map((name)=>_path.default.join(dir, name)).map((name)=>`@${name}`);
+    return _nodeFs.default.readdirSync(_nodePath.default.resolve(absoluteAppPath, dir)).map((name)=>_nodePath.default.join(dir, name)).map((name)=>`@${name}`);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullscript/eslint-plugin",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Fullscript custom eslint rules",
   "main": "dist/index.js",
   "contributors": [
@@ -21,6 +21,9 @@
     "build-watch": "swc ./src -d dist -w",
     "test": "jest ./src"
   },
+  "dependencies": {
+    "js-yaml": "^4.1.0"
+  },
   "devDependencies": {
     "@swc/cli": "^0.1.57",
     "@swc/core": "^1.3.20",
@@ -30,7 +33,6 @@
     "core-js": "^3.26.1",
     "husky": "^8.0.0",
     "jest": "^29.3.1",
-    "js-yaml": "^4.1.0",
     "prettier": "^2.8.0"
   }
 }

--- a/src/crossReference/crossReference.js
+++ b/src/crossReference/crossReference.js
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 import { getModules } from "./getModules";
 
 const meta = {
@@ -81,13 +81,20 @@ const create = context => {
       return jsModule;
     }
 
+    // Checks to see if the import path is a namespace within the application or an external node module
+    const isImportPathAnAppNamespace = config.modules.find(moduleName =>
+      moduleName.startsWith(importPath.split("/")[0])
+    );
+
     return (
-      config.modules.find(moduleName => importPath.startsWith(`${moduleName}/`)) ||
-      config.modules.find(moduleName => importPath.startsWith(moduleName))
+      isImportPathAnAppNamespace &&
+      (config.modules.find(moduleName => importPath.startsWith(`${moduleName}/`)) ||
+        config.modules.find(moduleName => importPath.startsWith(moduleName)))
     );
   };
 
   const isValidConfig = (node, config) => {
+    debugger;
     const fileModule = getModule(context.getFilename(), config);
     if (!fileModule) return true;
 

--- a/src/crossReference/getModules.js
+++ b/src/crossReference/getModules.js
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 const getModules = (absoluteAppPath, dir) => {
   return fs


### PR DESCRIPTION
Since we have a `@remix` path alias, the cross-reference rule thinks that imports to `@remix-run` violate the cross-reference boundary. This MR fixes that problem :).